### PR TITLE
Entire bible parsed for clustering

### DIFF
--- a/backend/utils/utils.py
+++ b/backend/utils/utils.py
@@ -4,46 +4,71 @@ from sklearn.metrics.pairwise import cosine_similarity
 import nltk
 nltk.download('gutenberg')
 from nltk.corpus import gutenberg
+
+
 # Load the KMeans model and TF-IDF vectorizer
 with open('models/kmeans_model.pkl', 'rb') as f:
     loaded_km = pickle.load(f)
 
-with open('models/vectorizer.pkl', 'rb') as f:
+with open('vectorizer.pkl', 'rb') as f:
     loaded_vectorizer = pickle.load(f)
 
 # Load and preprocess the Bible data
-bible = gutenberg.raw('bible-kjv.txt')
-books = bible.split('\n\n\n\n\n')
-John = books[53]
-John = John.split('\n\n')
+def load_bible_data():
+    bible = gutenberg.raw('bible-kjv.txt')
+    books = bible.split('\n\n\n\n\n')
 
-# Transform the John verses using the loaded TF-IDF vectorizer
-X_loaded = loaded_vectorizer.transform(John)
+    bible_data = {}
+#Splitting each book into chapters and verses
+    for book in books:
+        book_lines = book.split('\n\n')
+        book_name = book_lines[0].strip()
+        bible_data[book_name] = {}
 
-# Predict the clusters for the John verses
+        for chapter in book_lines[1:]:
+            chapter_lines = chapter.split("\n")
+            chapter_number = chapter_lines[0].strip()
+            verses = chapter_lines[1:]
+            bible_data[book_name][chapter_number] = verses
+
+    return bible_data
+
+bible_data = load_bible_data()
+
+# Transform the Bible verses using the loaded TF-IDF vectorizer
+bible_verses = []
+verse_indices = []
+for book, chapters in bible_data.items():
+    for chapter, verses in chapters.items():
+        for i, verse in enumerate(verses):
+            bible_verses.append(verse)
+            verse_indices.append((book, chapter, i+1))
+
+X_loaded = loaded_vectorizer.transform(bible_verses)
+
+# Predict the clusters for the Bible verses
 labels_loaded = loaded_km.predict(X_loaded)
 
 def get_similar_verses(user_input):
-    # Transform the user input using the loaded TF-IDF vectorizer
-    user_input_vector = loaded_vectorizer.transform([user_input])
 
-    # Predict the cluster for the user input
-    predicted_cluster = loaded_km.predict(user_input_vector)[0]
+        # Transform the user input using the loaded TF-IDF vectorizer
+        user_input_vector = loaded_vectorizer.transform([user_input])
 
-    # Get the indices of the verses in the predicted cluster
-    cluster_indices = np.where(labels_loaded == predicted_cluster)[0]
+        # Get the indices of the verses in the predicted cluster
+        cluster_indices = np.where(labels_loaded == loaded_km.predict(user_input_vector)[0])[0]
 
-    # Get the TF-IDF vectors for the verses in the predicted cluster
-    cluster_verses = [John[i] for i in cluster_indices]
-    cluster_vectors = X_loaded[cluster_indices]
+        # Get the TF-IDF vectors for the verses in the predicted cluster
+        cluster_vectors = X_loaded[cluster_indices]
 
-    # Compute similarity between the user input and each verse in the cluster
-    similarities = cosine_similarity(user_input_vector, cluster_vectors).flatten()
+        # Compute similarity between the user input and each verse in the cluster
+        similarities = cosine_similarity(user_input_vector, cluster_vectors).flatten()
 
-    # Get the indices of the top 5 most similar verses
-    top_indices = similarities.argsort()[-5:][::-1]
+        # Get the indices of the top 5 most similar verses
+        top_indices = similarities.argsort()[-5:][::-1]
 
-    # Prepare the results
-    results = [(cluster_verses[i], similarities[i]) for i in top_indices]
-    
-    return results
+        results = []
+        for index in top_indices:
+            book, chapter, verse_number = verse_indices[index]
+            results.append((f"{book} {chapter}:{verse_number}", bible_verses[index]))
+
+        return results


### PR DESCRIPTION
### Description

This PR updates the project to use the entire Bible for clustering, improving the accuracy and reducing the number of 0% similarity results. Additionally, the data storage has been reorganized, so each book stores its own chapters, which store their own scriptures. The printing of clusters now includes the book name with the verse number (e.g., Matthew 5:38), replacing the manual concatenation of 1 John.

### Related Issues

Fixes #123 (Bible clustering issue)
Related to #124 (Data storage improvement)

### Changes List
✅Updated the clustering to use the entire Bible instead of 1 John.

✅Reorganized data storage for the Gutenberg Bible, structuring by books, chapters, and scriptures.

✅ Modified cluster printing to include the book name attached to the verse number.


### Type of Changes
✅Bug fix (fixes an existing issue)

✅Enhancement (improves or changes existing functionality)

### Checklist
✅ My code follows the style guidelines of this project.

✅ I have performed a self-review of my code.

✅ I have commented my code, particularly in hard-to-understand areas.

✅ I have made corresponding changes to the issue .

✅ New and existing unit tests pass locally with my changes.